### PR TITLE
Check for unused imports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "phpstan/phpstan": "^0.11.16",
         "phpstan/phpstan-mockery": "^0.11.3",
         "phpunit/phpunit": "^8.3",
+        "slevomat/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "extra": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,4 +5,6 @@
     <file>src</file>
     <file>tests</file>
     <rule ref="PSR12"/>
+    <config name="installed_paths" value="../../slevomat/coding-standard"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
 </ruleset>


### PR DESCRIPTION
It is messy and Drupal Coding standards has a rule for detecting such
things. Let’s use that.