### PR TITLE
Add support for Lumen

### DIFF
--- a/src/ServiceProviders/StatisticsEventsServiceProvider.php
+++ b/src/ServiceProviders/StatisticsEventsServiceProvider.php
@@ -1,17 +1,26 @@
-<?php
+<?php // phpcs:disable PSR1.Files.SideEffects
 
 namespace DDB\Stats\ServiceProviders;
 
 use DDB\Stats\Events\StatisticsClaimed;
 use DDB\Stats\Listeners\RemoveObsoleteStatistics;
-use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 
-class StatisticsEventsServiceProvider extends EventServiceProvider
+// Laravel and Lumen have different base classes for event service providers.
+// If we detect a Lumen variant then use that class instead of the Laravel one.
+// That should be safe as long as we are using basic features.
+if (class_exists('\Laravel\Lumen\Providers\EventServiceProvider')) {
+    class_alias(
+        '\Laravel\Lumen\Providers\EventServiceProvider',
+        '\Illuminate\Foundation\Support\Providers\EventServiceProvider'
+    );
+}
+
+class StatisticsEventsServiceProvider extends \Illuminate\Foundation\Support\Providers\EventServiceProvider
 {
 
     protected $listen = [
-      StatisticsClaimed::class => [
-        RemoveObsoleteStatistics::class
-      ],
+        StatisticsClaimed::class => [
+            RemoveObsoleteStatistics::class
+        ],
     ];
 }


### PR DESCRIPTION
Use aliases and fully qualified class names to switch between classes.

[This approach has been seen used in Mockery](https://github.com/mockery/mockery/blob/master/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php#L25-L29).

It is hard to test but I have seen it working in `reload/material-list`.