### PR TITLE
Spec parity

### DIFF
--- a/migrations/2019_09_26_142531_create_statistics_table.php
+++ b/migrations/2019_09_26_142531_create_statistics_table.php
@@ -18,7 +18,7 @@ class CreateStatisticsTable extends Migration
             $table->timestamp('timestamp', 6);
             $table->string('guid')->nullable();
             $table->string('event');
-            $table->string('object_id')->nullable();
+            $table->string('collection_id')->nullable();
             $table->string('item_id')->nullable();
             $table->json('details');
 

--- a/migrations/2019_09_26_142531_create_statistics_table.php
+++ b/migrations/2019_09_26_142531_create_statistics_table.php
@@ -16,10 +16,10 @@ class CreateStatisticsTable extends Migration
     {
         Schema::create('statistics', function (Blueprint $table) {
             $table->timestamp('timestamp', 6);
-            $table->string('guid');
+            $table->string('guid')->nullable();
             $table->string('event');
-            $table->string('object_id');
-            $table->string('item_id');
+            $table->string('object_id')->nullable();
+            $table->string('item_id')->nullable();
             $table->json('details');
 
             $table->index('timestamp');

--- a/migrations/2019_09_26_142531_create_statistics_table.php
+++ b/migrations/2019_09_26_142531_create_statistics_table.php
@@ -20,7 +20,8 @@ class CreateStatisticsTable extends Migration
             $table->string('event');
             $table->string('collection_id')->nullable();
             $table->string('item_id')->nullable();
-            $table->json('details');
+            $table->integer('total_count')->nullable();
+            $table->json('content');
 
             $table->index('timestamp');
         });

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -26,7 +26,7 @@ class Collector implements StatisticsCollector
     public function event(
         ?string $guid,
         string $event,
-        ?string $object_id = null,
+        ?string $collection_id = null,
         ?string $item_id = null,
         array $details = []
     ): void {
@@ -34,7 +34,7 @@ class Collector implements StatisticsCollector
             'timestamp' => Carbon::now()->timestamp,
             'guid' => $guid,
             'event' => $event,
-            'object_id' => $object_id,
+            'collection_id' => $collection_id,
             'item_id' => $item_id,
             'details' => json_encode($details),
         ]);

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -26,18 +26,18 @@ class Collector implements StatisticsCollector
     public function event(
         ?string $guid,
         string $event,
-        ?string $collection_id = null,
-        ?string $item_id = null,
-        ?int $total_count = null,
+        ?string $collectionId = null,
+        ?string $itemId = null,
+        ?int $totalCount = null,
         array $content = []
     ): void {
         $this->database->table('statistics')->insert([
             'timestamp' => Carbon::now()->timestamp,
             'guid' => $guid,
             'event' => $event,
-            'collection_id' => $collection_id,
-            'item_id' => $item_id,
-            'total_count' => $total_count,
+            'collection_id' => $collectionId,
+            'item_id' => $itemId,
+            'total_count' => $totalCount,
             'content' => json_encode($content),
         ]);
     }

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -28,7 +28,8 @@ class Collector implements StatisticsCollector
         string $event,
         ?string $collection_id = null,
         ?string $item_id = null,
-        array $details = []
+        ?int $total_count = null,
+        array $content = []
     ): void {
         $this->database->table('statistics')->insert([
             'timestamp' => Carbon::now()->timestamp,
@@ -36,7 +37,8 @@ class Collector implements StatisticsCollector
             'event' => $event,
             'collection_id' => $collection_id,
             'item_id' => $item_id,
-            'details' => json_encode($details),
+            'total_count' => $total_count,
+            'content' => json_encode($content),
         ]);
     }
 }

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -23,8 +23,13 @@ class Collector implements StatisticsCollector
     /**
      * {@inheritdoc}
      */
-    public function event(string $guid, string $event, string $object_id, string $item_id, array $details = []): void
-    {
+    public function event(
+        ?string $guid,
+        string $event,
+        ?string $object_id = null,
+        ?string $item_id = null,
+        array $details = []
+    ): void {
         $this->database->table('statistics')->insert([
             'timestamp' => Carbon::now()->timestamp,
             'guid' => $guid,

--- a/src/Controllers/StatisticsController.php
+++ b/src/Controllers/StatisticsController.php
@@ -41,7 +41,7 @@ class StatisticsController extends Controller
             }
         }
 
-        $result = $query->get(['timestamp', 'guid', 'event', 'collection_id', 'item_id', 'details']);
+        $result = $query->get(['timestamp', 'guid', 'event', 'collection_id', 'item_id', 'total_count', 'content']);
         $response = $result->map(function (\stdClass $values) {
             return [
                 'date' => (Carbon::createFromTimestamp($values->timestamp))->toIso8601String(),
@@ -49,6 +49,8 @@ class StatisticsController extends Controller
                 'event' => $values->event,
                 'collectionId' => $values->collection_id,
                 'itemId' => $values->item_id,
+                'totalCount' => $values->total_count,
+                'content' => json_decode($values->content),
             ];
         });
 

--- a/src/Controllers/StatisticsController.php
+++ b/src/Controllers/StatisticsController.php
@@ -41,13 +41,13 @@ class StatisticsController extends Controller
             }
         }
 
-        $result = $query->get(['timestamp', 'guid', 'event', 'object_id', 'item_id', 'details']);
+        $result = $query->get(['timestamp', 'guid', 'event', 'collection_id', 'item_id', 'details']);
         $response = $result->map(function (\stdClass $values) {
             return [
                 'date' => (Carbon::createFromTimestamp($values->timestamp))->toIso8601String(),
                 'guid' => $values->guid,
                 'event' => $values->event,
-                'collectionId' => $values->object_id,
+                'collectionId' => $values->collection_id,
                 'itemId' => $values->item_id,
             ];
         });

--- a/src/StatisticsCollector.php
+++ b/src/StatisticsCollector.php
@@ -8,7 +8,7 @@ interface StatisticsCollector
     public function event(
         ?string $guid,
         string $event,
-        ?string $object_id = null,
+        ?string $collection_id = null,
         ?string $item_id = null,
         array $details = []
     ): void;

--- a/src/StatisticsCollector.php
+++ b/src/StatisticsCollector.php
@@ -13,13 +13,13 @@ interface StatisticsCollector
      *   is performed.
      * @param string $event
      *   The event name. Names use snake_case per convention.
-     * @param string|null $collection_id
+     * @param string|null $collectionId
      *   The id for a collection of items. What constitues a collection of items
      *   is defined by the system.
-     * @param string|null $item_id
+     * @param string|null $itemId
      *   The id for an item related to the event. What constitutes an item is
      *   defined by the system.
-     * @param int|null $total_count
+     * @param int|null $totalCount
      *   The total number of items/collections after the event has been
      *   completed if relevant for the event.
      * @param string[] $content
@@ -29,9 +29,9 @@ interface StatisticsCollector
     public function event(
         ?string $guid,
         string $event,
-        ?string $collection_id = null,
-        ?string $item_id = null,
-        ?int $total_count = null,
+        ?string $collectionId = null,
+        ?string $itemId = null,
+        ?int $totalCount = null,
         array $content = []
     ): void;
 }

--- a/src/StatisticsCollector.php
+++ b/src/StatisticsCollector.php
@@ -5,5 +5,11 @@ namespace DDB\Stats;
 interface StatisticsCollector
 {
 
-    public function event(string $guid, string $event, string $object_id, string $item_id, array $details = []): void;
+    public function event(
+        ?string $guid,
+        string $event,
+        ?string $object_id = null,
+        ?string $item_id = null,
+        array $details = []
+    ): void;
 }

--- a/src/StatisticsCollector.php
+++ b/src/StatisticsCollector.php
@@ -10,6 +10,7 @@ interface StatisticsCollector
         string $event,
         ?string $collection_id = null,
         ?string $item_id = null,
-        array $details = []
+        ?int $total_count = null,
+        array $content = []
     ): void;
 }

--- a/src/StatisticsCollector.php
+++ b/src/StatisticsCollector.php
@@ -5,6 +5,27 @@ namespace DDB\Stats;
 interface StatisticsCollector
 {
 
+    /**
+     * Register an event which occurred within the application.
+     *
+     * @param string|null $guid
+     *   The globally unique identifier for the user on behalf of who the event
+     *   is performed.
+     * @param string $event
+     *   The event name. Names use snake_case per convention.
+     * @param string|null $collection_id
+     *   The id for a collection of items. What constitues a collection of items
+     *   is defined by the system.
+     * @param string|null $item_id
+     *   The id for an item related to the event. What constitutes an item is
+     *   defined by the system.
+     * @param int|null $total_count
+     *   The total number of items/collections after the event has been
+     *   completed if relevant for the event.
+     * @param string[] $content
+     *   The ids within the collection after the completion of the event if
+     *   relevant for the event.
+     */
     public function event(
         ?string $guid,
         string $event,

--- a/tests/CollectorTest.php
+++ b/tests/CollectorTest.php
@@ -25,7 +25,7 @@ class CollectorTest extends TestCase
             'timestamp' => $now->timestamp,
             'guid' => 'guid',
             'event' => 'event',
-            'object_id' => 'object_id',
+            'collection_id' => 'collection_id',
             'item_id' => 'item_id',
             'details' => json_encode(['some' => 'value']),
         ])->once();
@@ -33,6 +33,6 @@ class CollectorTest extends TestCase
         $db->shouldReceive('table')->with('statistics')->andReturn($builder);
 
         $collector = new Collector($db);
-        $collector->event('guid', 'event', 'object_id', 'item_id', ['some' => 'value']);
+        $collector->event('guid', 'event', 'collection_id', 'item_id', ['some' => 'value']);
     }
 }

--- a/tests/CollectorTest.php
+++ b/tests/CollectorTest.php
@@ -27,12 +27,13 @@ class CollectorTest extends TestCase
             'event' => 'event',
             'collection_id' => 'collection_id',
             'item_id' => 'item_id',
-            'details' => json_encode(['some' => 'value']),
+            'total_count' => 42,
+            'content' => json_encode(['item1', 'item2']),
         ])->once();
         $db = \Mockery::mock(DatabaseManager::class);
         $db->shouldReceive('table')->with('statistics')->andReturn($builder);
 
         $collector = new Collector($db);
-        $collector->event('guid', 'event', 'collection_id', 'item_id', ['some' => 'value']);
+        $collector->event('guid', 'event', 'collection_id', 'item_id', 42, ['item1', 'item2']);
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -32,7 +32,7 @@ class IntegrationTest extends TestCase
         Carbon::setTestNow($now);
 
         $collector = $this->app->get(StatisticsCollector::class);
-        $collector->event('guid', 'event', 'object', 'item', ['extra1', 'extra2']);
+        $collector->event('guid', 'event', 'object', 'item', 42, ['item1', 'item2']);
 
         $response = $this->json('PATCH', 'statistics');
         $statistics = $response->json();
@@ -42,7 +42,9 @@ class IntegrationTest extends TestCase
                 'guid' => 'guid',
                 'event' => 'event',
                 'collectionId' => 'object',
-                'itemId' => 'item'
+                'itemId' => 'item',
+                'totalCount' => 42,
+                'content' => ['item1', 'item2'],
             ],
             $statistics[0]
         );
@@ -56,7 +58,7 @@ class IntegrationTest extends TestCase
         // Event is created yesterday
         Carbon::setTestNow($yesterday);
         $collector = $this->app->get(StatisticsCollector::class);
-        $collector->event('guid', 'event', 'object', 'item', ['extra1', 'extra2']);
+        $collector->event('guid', 'event', 'object', 'item', 42, ['item1', 'item2']);
 
         // Ensure that the event is available.
         $response = $this->json('PATCH', 'statistics');

--- a/tests/StatisticsControllerTest.php
+++ b/tests/StatisticsControllerTest.php
@@ -27,7 +27,8 @@ class StatisticsControllerTest extends TestCase
           'event' => 'event',
           'collection_id' => 'collection_id',
           'item_id' => 'item_id',
-          'details' => json_encode(['some' => 'value']),
+          'total_count' => 42,
+          'content' => json_encode(['item1', 'item2']),
         ]);
 
         $database = \Mockery::mock(DatabaseManager::class);
@@ -48,7 +49,9 @@ class StatisticsControllerTest extends TestCase
            'guid' => 'guid',
            'event' => 'event',
            'collectionId' => 'collection_id',
-           'itemId' => 'item_id'
+           'itemId' => 'item_id',
+           'totalCount' => 42,
+           'content' => ['item1', 'item2'],
         ]]);
         $this->assertEquals(
             $response,

--- a/tests/StatisticsControllerTest.php
+++ b/tests/StatisticsControllerTest.php
@@ -25,7 +25,7 @@ class StatisticsControllerTest extends TestCase
           'timestamp' => $now,
           'guid' => 'guid',
           'event' => 'event',
-          'object_id' => 'object_id',
+          'collection_id' => 'collection_id',
           'item_id' => 'item_id',
           'details' => json_encode(['some' => 'value']),
         ]);
@@ -47,7 +47,7 @@ class StatisticsControllerTest extends TestCase
            'date' => date('c', $now),
            'guid' => 'guid',
            'event' => 'event',
-           'collectionId' => 'object_id',
+           'collectionId' => 'collection_id',
            'itemId' => 'item_id'
         ]]);
         $this->assertEquals(


### PR DESCRIPTION
Update package to match API specification.

This means:
- Renaming a bunch of fields
- Adding a totalCount field
- Making select fields nullable
- Updating documentation