### PR TITLE
Upgrading to lumen 8

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker://php:7.3-alpine
         with:
           entrypoint: vendor/bin/phpstan
-          args: analyse
+          args: analyse --memory-limit 1G
   unit_tests:
     name: Unit tests
     if: '!github.event.deleted'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker://php:7.3-alpine
         with:
           entrypoint: vendor/bin/phpstan
-          args: analyse --memory-limit 1G
+          args: analyse --memory-limit=-1
   unit_tests:
     name: Unit tests
     if: '!github.event.deleted'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["7.2", "7.3", "7.4"]
+        php-version: ["7.3", "7.4"]
         composer-update: ["", "--prefer-stable --prefer-lowest"]
       fail-fast: false
     steps:
@@ -47,10 +47,11 @@ jobs:
           php-version: ${{ matrix.php-version }}
           # These extensions are required by PHP 7.4
           extension-csv: mbstring, xmlwriter
+          coverage: xdebug
       - name: Composer update
         run: composer update ${{ matrix.composer-update }}
       - name: Unit tests
-        run: phpdbg -qrr vendor/bin/phpunit
+        run: ./vendor/bin/phpunit
       - name: Unit Codecov
         if: matrix.php-version == '7.3' && !matrix.composer-update
         uses: Atrox/codecov-action@v0.1.3

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "laravel/lumen-framework": "^7.0"
+        "laravel/lumen-framework": "^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
     "require-dev": {
         "jangregor/phpstan-prophecy": "^1.0",
         "nunomaduro/larastan": "^1.0.0",
-        "orchestra/testbench": "^5.0",
+        "orchestra/testbench": "^6.7",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^1.3",
         "phpstan/phpstan-mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "illuminate/database": "^6.0",
-        "illuminate/support": "^6.0"
+        "laravel/lumen-framework": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -20,17 +19,19 @@
     },
     "license": "AGPL",
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     },
     "require-dev": {
-        "jangregor/phpstan-prophecy": "^0.4.2",
-        "laravel/lumen-framework": "^6.0",
-        "nunomaduro/larastan": "^0.4.1",
-        "orchestra/testbench": "^4.2",
+        "jangregor/phpstan-prophecy": "^1.0",
+        "nunomaduro/larastan": "^1.0.0",
+        "orchestra/testbench": "^5.0",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "^0.11.16",
-        "phpstan/phpstan-mockery": "^0.11.3",
-        "phpunit/phpunit": "^8.3",
+        "phpstan/phpstan": "^1.3",
+        "phpstan/phpstan-mockery": "^1.0",
+        "phpunit/phpunit": "^9.5",
         "slevomat/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,22 @@
-<phpunit bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Unit tests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="DB_CONNECTION" value="testing"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-    </php>
-    <logging>
-        <log type="coverage-clover" target="clover.xml"/>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-    </logging>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <clover outputFile="clover.xml"/>
+      <text outputFile="php://stdout" showUncoveredFiles="true"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="DB_CONNECTION" value="testing"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+  </php>
+  <logging/>
 </phpunit>

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -7,7 +7,6 @@ use Illuminate\Database\DatabaseManager;
 
 class Collector implements StatisticsCollector
 {
-
     /**
      * Database to store stats in.
      *

--- a/src/Controllers/StatisticsController.php
+++ b/src/Controllers/StatisticsController.php
@@ -7,12 +7,12 @@ use DDB\Stats\Events\StatisticsClaimed;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Laravel\Lumen\Routing\Controller;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class StatisticsController extends Controller
 {
-
     /** @var \Illuminate\Database\DatabaseManager */
     private $database;
 
@@ -25,13 +25,15 @@ class StatisticsController extends Controller
         $this->dispatchcer = $dispatcher;
     }
 
-    public function patch(Request $request)
+    public function patch(Request $request): Collection
     {
         $query = $this->database->table('statistics')
             ->orderBy('timestamp', 'ASC');
         if ($request->has('since')) {
+            /** @var string $sinceParam */
+            $sinceParam = $request->get('since');
             try {
-                $since = Carbon::createFromFormat(DATE_ATOM, $request->get('since'));
+                $since = Carbon::createFromFormat(DATE_ATOM, $sinceParam);
                 if (!$since) {
                     throw new \InvalidArgumentException('Unable to create date from format');
                 }

--- a/src/Events/StatisticsClaimed.php
+++ b/src/Events/StatisticsClaimed.php
@@ -6,7 +6,7 @@ use Carbon\CarbonInterface;
 
 class StatisticsClaimed
 {
-    /* @var \Carbon\CarbonInterface|null */
+    /** @var \Carbon\CarbonInterface|null */
     protected $since;
 
     /**
@@ -20,6 +20,6 @@ class StatisticsClaimed
 
     public function getSince(): ?CarbonInterface
     {
-        return  $this->since;
+        return $this->since;
     }
 }

--- a/src/Listeners/RemoveObsoleteStatistics.php
+++ b/src/Listeners/RemoveObsoleteStatistics.php
@@ -8,6 +8,7 @@ use Illuminate\Database\DatabaseManager;
 
 class RemoveObsoleteStatistics implements ShouldQueue
 {
+    /** @var \Illuminate\Database\DatabaseManager */
     private $database;
 
     public function __construct(DatabaseManager $database)

--- a/src/ServiceProviders/StatisticsEventsServiceProvider.php
+++ b/src/ServiceProviders/StatisticsEventsServiceProvider.php
@@ -17,7 +17,7 @@ if (class_exists('\Laravel\Lumen\Providers\EventServiceProvider')) {
 
 class StatisticsEventsServiceProvider extends \Illuminate\Foundation\Support\Providers\EventServiceProvider
 {
-
+    /** @var string[][] */
     protected $listen = [
         StatisticsClaimed::class => [
             RemoveObsoleteStatistics::class

--- a/src/ServiceProviders/StatisticsServiceProvider.php
+++ b/src/ServiceProviders/StatisticsServiceProvider.php
@@ -10,6 +10,8 @@ class StatisticsServiceProvider extends ServiceProvider
 {
     protected function loadRoutesFrom($path)
     {
+        // $router is needed by the required route file.
+        /** @phpstan-ignore-next-line */
         if ($router = $this->app->router ?? $this->app->make('router')) {
             require $path;
         }

--- a/src/ServiceProviders/StatisticsServiceProvider.php
+++ b/src/ServiceProviders/StatisticsServiceProvider.php
@@ -8,11 +8,9 @@ use Illuminate\Support\ServiceProvider;
 
 class StatisticsServiceProvider extends ServiceProvider
 {
-
     protected function loadRoutesFrom($path)
     {
-        if (! $this->app->routesAreCached()) {
-            $router = $this->app->make('router');
+        if ($router = $this->app->router ?? $this->app->make('router')) {
             require $path;
         }
     }

--- a/src/StatisticsCollector.php
+++ b/src/StatisticsCollector.php
@@ -4,7 +4,6 @@ namespace DDB\Stats;
 
 interface StatisticsCollector
 {
-
     /**
      * Register an event which occurred within the application.
      *

--- a/tests/CollectorTest.php
+++ b/tests/CollectorTest.php
@@ -15,7 +15,7 @@ class CollectorTest extends TestCase
     /**
      * Test that adding events sends it to the DB.
      */
-    public function testEvent()
+    public function testEvent(): void
     {
         $now = Carbon::now();
         Carbon::setTestNow($now);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -4,13 +4,13 @@ namespace DDB\Stats;
 
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
-use DDB\Stats\ServiceProviders\StatisticsServiceProvider;
-use Illuminate\Foundation\Testing\PendingCommand;
 use Orchestra\Testbench\TestCase;
+use DDB\Stats\StatisticsCollector;
+use Illuminate\Testing\PendingCommand;
+use DDB\Stats\ServiceProviders\StatisticsServiceProvider;
 
 class IntegrationTest extends TestCase
 {
-
     public function getPackageProviders($app)
     {
         return [StatisticsServiceProvider::class];
@@ -26,16 +26,19 @@ class IntegrationTest extends TestCase
         }
     }
 
-    public function testEvents()
+    public function testEvents(): void
     {
         $now = Carbon::now();
         Carbon::setTestNow($now);
 
+        /** @var \DDB\Stats\StatisticsCollector $collector */
         $collector = $this->app->get(StatisticsCollector::class);
         $collector->event('guid', 'event', 'object', 'item', 42, ['item1', 'item2']);
 
         $response = $this->json('PATCH', 'statistics');
-        $statistics = $response->json();
+        /* @var array<string, mixed> $statistics */
+        $statistics = (array) $response->json();
+
         $this->assertEquals(
             [
                 'date' => $now->toIso8601String(),
@@ -50,29 +53,30 @@ class IntegrationTest extends TestCase
         );
     }
 
-    public function testSince()
+    public function testSince(): void
     {
         $now = CarbonImmutable::now();
         $yesterday = $now->subDay();
 
         // Event is created yesterday
         Carbon::setTestNow($yesterday);
+        /** @var \DDB\Stats\StatisticsCollector $collector */
         $collector = $this->app->get(StatisticsCollector::class);
         $collector->event('guid', 'event', 'object', 'item', 42, ['item1', 'item2']);
 
         // Ensure that the event is available.
         $response = $this->json('PATCH', 'statistics');
-        $this->assertEquals(1, count($response->json()));
+        $this->assertEquals(1, count((array) $response->json()));
 
         // Retrieve events occurred in the last 6 hours. Event should not be
         // available since it occurred yesterday.
         // This should also delete the event.
         $time = $now->subHours(6);
         $response = $this->json('PATCH', 'statistics?since=' . urlencode($time->toIso8601String()));
-        $this->assertEquals(0, count($response->json()));
+        $this->assertEquals(0, count((array) $response->json()));
 
         // No event should be available now as it has been deleted.
         $response = $this->json('PATCH', 'statistics');
-        $this->assertEquals(0, count($response->json()));
+        $this->assertEquals(0, count((array) $response->json()));
     }
 }

--- a/tests/StatisticsControllerTest.php
+++ b/tests/StatisticsControllerTest.php
@@ -17,7 +17,7 @@ class StatisticsControllerTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    public function testPatch()
+    public function testPatch(): void
     {
         $now = Carbon::now();
 
@@ -60,7 +60,7 @@ class StatisticsControllerTest extends TestCase
         );
     }
 
-    public function testSince()
+    public function testSince(): void
     {
         $now = Carbon::now();
 
@@ -99,7 +99,7 @@ class StatisticsControllerTest extends TestCase
         $this->assertInstanceOf(Collection::class, $response);
     }
 
-    public function testInvalidSince()
+    public function testInvalidSince(): void
     {
         $database = \Mockery::mock(DatabaseManager::class);
         $database->shouldReceive('table->orderBy');


### PR DESCRIPTION
#### What does this PR do?
* Upgrades Lumen from 6.x to 8.x
* Fixes an error in the StatisticsServiceProvider caused by the change in framework version.
* Fixes phpStan execution in GH action by raising memory limit.
* Transform the phpunit configuration into new 9.0 format.

#### Where should the reviewer start?
Go through commits
Run tests locally

Note:
* My VS Code setup apparently orders the imports after length. I tried to change the ordering to be alphabetical but did not immediately find a solution. If it is a pain point for the general code style I can investigate it further :)